### PR TITLE
Predict_proba doesn't produce probabilities

### DIFF
--- a/hyperfast/hyperfast.py
+++ b/hyperfast/hyperfast.py
@@ -302,7 +302,7 @@ class HyperFastClassifier(BaseEstimator):
                 yhats.append(predicted)
 
             yhats = torch.stack(yhats)
-            yhats = torch.sum(yhats, axis=0)
+            yhats = torch.mean(yhats, axis=0)
             return yhats.cpu().numpy()
 
     def predict(self, X):


### PR DESCRIPTION
I had problems doing evaluations with the current code, because it seemed like probabilities always sum to 16, as you can check with
```python
from hyperfast import HyperFastClassifier
from sklearn.model_selection import train_test_split
from sklearn.datasets import load_iris
X, y = load_iris(return_X_y=True)
X_train, X_test, y_train, y_test = train_test_split(X, y)
hf = HyperFastClassifier().fit(X_train, y_train)
hf.predict_proba(X_test).sum(axis=1)
```
I assume the line I changed in this PR is responsible? I didn't actually test the change yet, though.