### PR TITLE
Optimize memory and improve code

### DIFF
--- a/hyperfast/model.py
+++ b/hyperfast/model.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from sklearn.decomposition import PCA
-from .utils import *
+from .utils import TorchPCA, get_main_weights, forward_linear_layer
 
 
 class HyperFast(nn.Module):


### PR DESCRIPTION
- Only move data to the device if needed.
- Use batching in inference (`predict_proba`) to avoid OOM error in CUDA.
- Add `nn_bias_mini_batches` option to control batching in NN bias.
- Add `weights_only=True` to `torch.load` to fix PyTorch warning.
- Minor code improvements.